### PR TITLE
Explicitly casting to string when printing the matrix.

### DIFF
--- a/R/print_basic_table.R
+++ b/R/print_basic_table.R
@@ -45,7 +45,12 @@ print.Tablespan <- function(x, digits = 2, n = 3, ...){
   if(!is.null(x$header$lhs)){
     cls <- 1:ncol(x$table_data$row_data)
     header_table[rws, cls] <- x$table_data$row_data |>
-      sapply(function(x) if(is.numeric(x) & !is.integer(x)){round(x, digits)}else{x}) |>
+      sapply(function(x)
+        if(is.numeric(x) & !is.integer(x)){
+          as.character(round(x, digits))
+        }else{
+          as.character(x)
+        }) |>
       utils::head(n = n)
 
     # add vertical line
@@ -57,7 +62,12 @@ print.Tablespan <- function(x, digits = 2, n = 3, ...){
   }
 
   header_table[rws, cls] <- x$table_data$col_data |>
-    sapply(function(x) if(is.numeric(x) & !is.integer(x)){round(x, digits)}else{x}) |>
+    sapply(function(x)
+      if(is.numeric(x) & !is.integer(x)){
+        as.character(round(x, digits))
+      }else{
+        as.character(x)
+      }) |>
     utils::head(n = n)
 
   # add horizontal line

--- a/tests/testthat/test-print_table.R
+++ b/tests/testthat/test-print_table.R
@@ -31,3 +31,18 @@ test_that("print", {
   testthat::expect_no_error(print.Tablespan(tablespan(data = summarized_table,
                                                       formula = 1 ~ (Horsepower = Mean:mean_hp + SD:sd_hp))))
 })
+
+test_that("print factors", {
+  library(tibble)
+  library(tablespan)
+
+  tibble(x = factor(LETTERS[1:5],
+                    levels = LETTERS[1:5]),
+         y = 1:5,
+         z = seq(0,1, length.out = 5)) |>
+    tablespan(x + z ~ y) |>
+    tablespan:::print.Tablespan() |>
+    testthat::expect_output("| A   0    | 1   |")
+
+
+})


### PR DESCRIPTION
This addresses an issue, where factors were cast to int implicitly when combined with another numeric variable.

See #49